### PR TITLE
added X-Forwarded-Port and fixed X-Forwarded-Proto and removed HSTS

### DIFF
--- a/nginx-config/backend
+++ b/nginx-config/backend
@@ -9,7 +9,7 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/main/privkey.pem;
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers         HIGH:!aNULL:!MD5;
-  add_header          Strict-Transport-Security "max-age=31536000";
+  #add_header          Strict-Transport-Security "max-age=31536000";
 
   location / {
     proxy_pass http://backend;
@@ -18,8 +18,9 @@ server {
     proxy_set_header X-Forwarded-Server   $host;
     proxy_set_header X-Real-IP            $remote_addr;
     proxy_set_header X-Forwarded-For      $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto    $remote_addr;
+    proxy_set_header X-Forwarded-Proto    $scheme;
     proxy_set_header X-Forwarded-Protocol $scheme;
+    proxy_set_header X-Forwarded-Port     $server_port;
     proxy_set_header Host                 $http_host;
 
     proxy_redirect  off;

--- a/nginx-config/backend
+++ b/nginx-config/backend
@@ -9,7 +9,7 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/main/privkey.pem;
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers         HIGH:!aNULL:!MD5;
-  #add_header          Strict-Transport-Security "max-age=31536000";
+  add_header          Strict-Transport-Security "max-age=31536000";
 
   location / {
     proxy_pass http://backend;


### PR DESCRIPTION
Hi,
Added X-Forwarded-Port as it might be used by some applications.
Fixed X-Forwarded-Proto, it was set to $remote_addr which is wrong.

Commented out the HSTS. IMO I feel like forcing TLS on a hostname should be optional.
So perhaps we can make a fix to have that setting enabled or disable via a environment variable?
Or if you don't agree, you can just undo my line 12 change. You have been given access to edit this PR